### PR TITLE
ajout doc styles et geostyler

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -2,7 +2,7 @@
 
 ## Installation et configuration
 
-Le portail est construit sur le framework PHP Symfony. Il nécessite l'installation d'un moteur php >=7.1.3 avec les extensions `xsl` et `intl` ainsi que le logiciel Yarn.
+Le portail est construit sur le framework PHP Symfony. Il nécessite l'installation d'un moteur php >=7.4 avec les extensions `xsl` et `intl` ainsi que le logiciel Yarn.
 
 1. S'assurer que le proxy est correctement configuré (par exemple au moyen des variables d'environnement `http_proxy` et `https_proxy`)
 

--- a/docs/developer/style.md
+++ b/docs/developer/style.md
@@ -1,0 +1,23 @@
+# Style pour le rendu cartographique des tuiles vectorielles
+
+Le format privilégié pour appliquer un style à un flux de tuiles vectorielles est le JSON conforme aux [spécifications de style Mapbox GL](https://docs.mapbox.com/mapbox-gl-js/style-spec/), parfois appelé **MbStyle**.
+
+C'est systématiquement un fichier dans ce format qui est téléversé en tant qu'annexe pour être rendu disponible aux utilisateurs finaux du flux.
+
+Il est possible de soumettre des fichiers de style dans 3 formats. Voici les manipulations effectuées par le Géotuileur pour chacun d'entre-eux :
+
+## MbStyle
+
+Si l'utilisateur soumet un fichier MbStyle, avant de l'envoyer à l'API, le Géotuileur va s'assurer que chaque `source-layer` des `layers` qui le composent existe bien dans les tuiles vectorielles et compléter la partie `sources` avec l'URL du flux.
+
+## QML
+
+Si l'utilisateur dispose de fichiers QML, il doit en envoyer un par couche présente dans les tuiles vectorielles. Ils sont ensuite convertis en MbStyle avec Geostyler (notamment [geostyler-qgis-parser](https://github.com/geostyler/geostyler-qgis-parser/) et [geostyler-mapbox-parser](https://github.com/geostyler/geostyler-mapbox-parser/)) et combinés en un seul fichier avec ajout de la section `source`.
+
+## SLD
+
+Le processus appliqué est identique à ce qui est fait dans le cas de fichiers QML, en utilisant cette fois [geostyler-sld-parser](https://github.com/geostyler/geostyler-sld-parser/).
+
+----
+
+> NB : l'affichage cartographique sur le site est réalisé avec openlayers et [ol-mapbox-style](https://github.com/openlayers/ol-mapbox-style). Toutes les possibilités du format MbStyle ne sont pas pleinement exploitées par cet affichage. Une bibliothèque plus nativement dédiée au format MbStyle comme [MapLibre](https://github.com/maplibre/maplibre-gl-js) pourrait dans ce cas être une meilleure option pour visualiser le flux et son style.

--- a/docs/developer/workflow.md
+++ b/docs/developer/workflow.md
@@ -93,7 +93,7 @@ Cette phase facultative consiste à fabriquer des fichiers de styles applicables
 
 > NB : Cette étape est facultative car l'application d'un style sur un flux de tuiles vectorielles pour fabriquer une carte est réalisée par l'application cliente de l'utilisateur final (SIG ou application web par exemple). Le style peut être fourni complètement séparément du flux de données et n'a pas obligatoirement à être géré par le Géotuileur.
 
-L'interface permet de téléverser un fichier de style au format JSON Mapbox et le rendre disponible sur le web via le concept d'annexe (`annexe`) de l'API. C'est le Géotuileur qui décide du chemin d'accès public (`path`) à cette annexe.
+L'interface permet de téléverser un fichier de style au format JSON Mapbox (tout autre format est transformé à l'aide de [geostyler](./style.md)) et le rendre disponible sur le web via le concept d'annexe (`annexe`) de l'API. C'est le Géotuileur qui décide du chemin d'accès public (`path`) à cette annexe.
 
 Une fois une annexe ajoutée, la donnée stockée se voit ajouter l'identifiant de cette annexe dans son étiquette `styles` qui contient un objet de la forme :
 


### PR DESCRIPTION
Ajout d'une page de doc développeur décrivant ce qui est fait sur les fichiers de style soumis par l'utilisateur, notamment en utilisant les parsers Geostyler.