### PR TITLE
Issue #114 et #115 : gestion du fait que l'on puisse être membre de plusieurs "bacs à sable"

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -26,8 +26,17 @@ class UserController extends AbstractController
      */
     public function me(): Response
     {
+        $me = $this->plageApi->user->getMe();
+
+        $communities = [];
+        $communitiesMember = $me['communities_member'];
+        foreach ($communitiesMember as $communityMember) {
+            $communities[] = $this->plageApi->community->get($communityMember['community']['_id']);
+        }
+
         return $this->render('pages/user/me.html.twig', [
-            'user' => $this->plageApi->user->getMe(),
+            'user' => $me,
+            'communities' => $communities
         ]);
     }
 }

--- a/templates/pages/datastore/index.html.twig
+++ b/templates/pages/datastore/index.html.twig
@@ -15,6 +15,8 @@
         <div class="container-content">
             <div class="o-mea">
                 <div class="mea-container">
+
+                    {# Espaces de travail "standards" #}
                     {% for datastore in datastores %}
                         <div class="mea-item">
                             <a href="{{ path('plage_datastore_view', { datastoreId: datastore._id }) }}">
@@ -26,9 +28,11 @@
                             </a>
                         </div>
                     {% endfor %}
+
+                    {# Mon espace de test (Bac à sable) #}
                     {% set target = '' %}
-                    {% if datastoreBAS._id != -1 %}
-                        {% set target = path('plage_datastore_view', { datastoreId: datastoreBAS._id }) %}
+                    {% if mySandboxDatastore._id != -1 %}
+                        {% set target = path('plage_datastore_view', { datastoreId: mySandboxDatastore._id }) %}
                     {% elseif serviceAccount is not empty %}
                         {% set target = path('plage_datastore_create_sandbox') %}
                     {% endif %}
@@ -43,6 +47,19 @@
                             </a>
                         </div>
                     {% endif %}
+
+                    {# Les bacs à sable des autres #}
+                    {% for datastore in otherSandboxDatastores %}
+                        <div class="mea-item">
+                            <a href="{{ path('plage_datastore_view', { datastoreId: datastore._id }) }}">
+                                <img class="mea-img" src="{{ asset('build/img/datastore/bac-a-sable.svg') }}"/>
+                                <h3>{{ 'datastore.index.access_other_test' | trans({'%first_name%': datastore.community.supervisor.first_name, '%last_name%': datastore.community.supervisor.last_name}) }}</h3>
+                                <p>
+                                    <span class="btn btn--plain btn--accent">{{ 'datastore.index.access_action' | trans }}</span>
+                                </p>
+                            </a>
+                        </div>
+                    {% endfor %}
                 </div>
             </div>
         </div>

--- a/templates/pages/user/me.html.twig
+++ b/templates/pages/user/me.html.twig
@@ -23,11 +23,12 @@
 
             <p>{{ "user.me.member"| trans }}</p>
             <ul>
-            {% for member in user.communities_member %}
+            {% for community in communities %}
                 <li>
-                    <a href="{{ path('plage_datastore_view', { datastoreId: member.community.datastore }) }}">
-                        {{ member.community.name }}
+                    <a href="{{ path('plage_datastore_view', { datastoreId: community.datastore._id }) }}">
+                        {{ community.name }}
                     </a>
+                    ({{ "user.me.supervisor"| trans }}&nbsp;: {{ community.supervisor.first_name }} {{ community.supervisor.last_name }})
                 </li>
             {% endfor %}
             </ul>

--- a/translations/PlageWebClient.fr.yml
+++ b/translations/PlageWebClient.fr.yml
@@ -102,6 +102,7 @@ datastore:
         access_action: "Accéder"
         access_test: "Testez le service sur l'espace de test"
         access_test_action: "Accéder"
+        access_other_test: "Accédez à l'espace de test de %first_name% %last_name%"
         contact: "Contactez nos services pour ajouter un espace de travail"
 
     dashboard:

--- a/translations/PlageWebClient.fr.yml
+++ b/translations/PlageWebClient.fr.yml
@@ -93,6 +93,7 @@ user:
         creation: "Date d'inscription"
         id: "Identifiant technique"
         member: "Vous avez accès aux espaces de travail :"
+        supervisor: "Superviseur"
 
 datastore:
     index:


### PR DESCRIPTION
Sur la page Mon compte : 
- affiche le nom du superviseur de toutes les communautés entre parenthèses (#114)

Sur la page Mes espaces de travail : 
- liste les espaces de tests (bacs à sable) des autres utilisateurs auxquels l'utilisateur connecté appartient (#115). Le nom du superviseur est indiqué pour les distinguer de l'espace de test de l'utilisateur connecté.